### PR TITLE
Patch fix bot name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2463,6 +2464,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 serde_json = "1"
 openssl = "0.10"
 dotenv = "0.15"
-reqwest = { version = "0.11.4", features = ["json", "blocking"] }
+reqwest = { version = "0.11.4", features = ["json", "blocking", "socks"] }
 regex = "1"
 lazy_static = "1"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Triagebot
 
-This is the triage and team assistance bot for the rust-lang organization.
+这是为DragonOS Community提供分类和团队协助的机器人。
+
+它基于rust-lang的triagebot修改而来，感谢triagebot的作者们！
 
 Please see the [forge] for our documentation, and feel free to contribute edits
 if you find something helpful!
@@ -16,9 +18,8 @@ Triagebot can then respond to those notifications to perform various actions suc
 The Triagebot webserver also includes several other endpoints intended for users to access directly, such as https://triage.rust-lang.org/agenda.
 
 Triagebot uses a Postgres database to retain some state.
-In production, it uses [RDS](https://aws.amazon.com/rds/).
 
-The server at https://triage.rust-lang.org/ runs on ECS and is configured via [Terraform](https://github.com/rust-lang/simpleinfra/blob/master/terraform/shared/services/triagebot/main.tf#L8).
+triagebot服务的网址是 https://triagebot.dragonos.org.cn/ ， 它运行在由中国雅安大数据产业园赞助的服务器上。 
 Updates are automatically deployed when merged to master.
 
 ## Installation
@@ -48,7 +49,7 @@ The general overview of what you will need to do:
 
 5. Run `cargo run --bin triagebot`. This starts the http server listening for webhooks on port 8000.
 6. Add a `triagebot.toml` file to the main branch of your GitHub repo with whichever services you want to try out.
-7. Try interacting with your repo, such as issuing `@rustbot` commands or interacting with PRs and issues (depending on which services you enabled in `triagebot.toml`). Watch the logs from the server to see what's going on.
+7. Try interacting with your repo, such as issuing `@dragonosbot` commands or interacting with PRs and issues (depending on which services you enabled in `triagebot.toml`). Watch the logs from the server to see what's going on.
 
 ### Configure a database
 

--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -283,7 +283,7 @@ pub mod project_items {
     #[derive(cynic::QueryFragment, Debug)]
     #[cynic(variables = "Arguments")]
     pub struct Query {
-        #[arguments(login: "rust-lang")]
+        #[arguments(login: "DragonOS-Community")]
         pub organization: Option<Organization>,
     }
 

--- a/parser/src/command.rs
+++ b/parser/src/command.rs
@@ -289,8 +289,8 @@ fn move_input_along_1() {
 
 #[test]
 fn multiname() {
-    let input = "@rustbot label to: +bug. Afterwards, delete the world. @triagebot prioritize";
-    let mut input = Input::new(input, vec!["triagebot", "rustbot"]);
+    let input = "@dragonosbot label to: +bug. Afterwards, delete the world. @triagebot prioritize";
+    let mut input = Input::new(input, vec!["triagebot", "dragonosbot"]);
     assert!(dbg!(input.next().unwrap()).is_ok());
     assert_eq!(
         &input.all[input.parsed..],

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,7 +247,7 @@ pub(crate) struct MajorChangeConfig {
     // This has a default primarily for backwards compatibility.
     #[serde(default = "MajorChangeConfig::enabling_label_default")]
     pub(crate) enabling_label: String,
-    /// This is the label applied when issuing a `@rustbot second` command, it
+    /// This is the label applied when issuing a `@dragonosbot second` command, it
     /// indicates that the proposal has moved into the 10 day waiting period.
     pub(crate) second_label: String,
     /// This is the label applied after the waiting period has successfully

--- a/src/github.rs
+++ b/src/github.rs
@@ -1718,7 +1718,7 @@ impl<'q> IssuesQuery for Query<'q> {
         };
 
         let mut issues_decorator = Vec::new();
-        let re = regex::Regex::new("https://github.com/rust-lang/|/").unwrap();
+        let re = regex::Regex::new("https://github.com/DragonOS-Community/|/").unwrap();
         let re_zulip_link = regex::Regex::new(r"\[stream\]:\s").unwrap();
         for issue in issues {
             let fcp_details = if include_fcp_details {

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -2,9 +2,9 @@
 //!
 //! This supports several ways for setting issue/PR assignment:
 //!
-//! * `@rustbot assign @gh-user`: Assigns to the given user.
-//! * `@rustbot claim`: Assigns to the comment author.
-//! * `@rustbot release-assignment`: Removes the commenter's assignment.
+//! * `@dragonosbot assign @gh-user`: Assigns to the given user.
+//! * `@dragonosbot claim`: Assigns to the comment author.
+//! * `@dragonosbot release-assignment`: Removes the commenter's assignment.
 //! * `r? @user`: Assigns to the given user (PRs only).
 //!
 //! This is capable of assigning to any user, even if they do not have write

--- a/src/handlers/docs_update.rs
+++ b/src/handlers/docs_update.rs
@@ -1,4 +1,6 @@
 //! A scheduled job to post a PR to update the documentation on rust-lang/rust.
+// 暂时允许unreachable code, 因为我们目前不需要这个任务,只是为了方便注释它。
+#![allow(unreachable_code)]
 
 use crate::github::{self, GitTreeEntry, GithubClient, Issue, Repository};
 use crate::jobs::Job;
@@ -26,6 +28,7 @@ const SUBMODULES: &[&str] = &[
 
 const TITLE: &str = "Update books";
 
+/// 这个任务用于更新文档仓库的submodule，并在文档仓库创建PR
 pub struct DocsUpdateJob;
 
 #[async_trait]
@@ -39,6 +42,10 @@ impl Job for DocsUpdateJob {
         _ctx: &super::Context,
         _metadata: &serde_json::Value,
     ) -> anyhow::Result<()> {
+        // 我们目前暂时不需要这个，因此直接返回Ok
+
+        return Ok(());
+
         // Only run every other week. Doing it every week can be a bit noisy, and
         // (rarely) a PR can take longer than a week to merge (like if there are
         // CI issues). `Schedule` does not allow expressing this, so check it

--- a/src/handlers/major_change.rs
+++ b/src/handlers/major_change.rs
@@ -270,7 +270,7 @@ async fn handle(
         \n \
         ``` \
         \n \
-        @rustbot concern reason-for-concern \
+        @dragonosbot concern reason-for-concern \
         \n \
         <description of the concern> \
         \n \
@@ -280,7 +280,7 @@ async fn handle(
         \n \
         ``` \
         \n \
-        @rustbot resolve reason-for-concern \
+        @dragonosbot resolve reason-for-concern \
         \n \
         ``` \
         \n\n \

--- a/src/handlers/milestone_prs.rs
+++ b/src/handlers/milestone_prs.rs
@@ -20,13 +20,13 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
     }
 
     let repo = e.issue.repository();
-    if !(repo.organization == "rust-lang" && repo.repository == "rust") {
+    if !(repo.organization == "DragonOS-Community" && repo.repository == "DragonOS") {
         return Ok(());
     }
 
     if !e.issue.merged {
         log::trace!(
-            "Ignoring closing of rust-lang/rust#{}: not merged",
+            "Ignoring closing of DragonOS-Community/DragonOS#{}: not merged",
             e.issue.number
         );
         return Ok(());
@@ -36,7 +36,7 @@ pub async fn handle(ctx: &Context, event: &Event) -> anyhow::Result<()> {
         s
     } else {
         log::error!(
-            "rust-lang/rust#{}: no merge_commit_sha in event",
+            "DragonOS-Community/DragonOS#{}: no merge_commit_sha in event",
             e.issue.number
         );
         return Ok(());
@@ -80,7 +80,7 @@ async fn get_version_standalone(
     let resp = gh
         .raw()
         .get(&format!(
-            "https://raw.githubusercontent.com/rust-lang/rust/{}/src/version",
+            "https://raw.githubusercontent.com/DragonOS-Community/DragonOS/{}/src/version",
             merge_sha
         ))
         .send()

--- a/src/handlers/note.rs
+++ b/src/handlers/note.rs
@@ -3,7 +3,7 @@
 //! Users can make a new summary entry by commenting the following:
 //!
 //! ```md
-//! @rustbot note summary-title
+//! @dragonosbot note summary-title
 //! ```
 //!
 //! If this is the first summary entry, rustbot will amend the original post (the top-level comment) to add a "Notes" section. The section should **not** be edited by hand.

--- a/src/handlers/pull_requests_assignment_update.rs
+++ b/src/handlers/pull_requests_assignment_update.rs
@@ -22,8 +22,8 @@ impl Job for PullRequestAssignmentUpdate {
 
         tracing::trace!("starting pull_request_assignment_update");
 
-        let rust_repo = gh.repository("rust-lang/rust").await?;
-        let prs = retrieve_pull_requests(&rust_repo, &gh).await?;
+        let dragonos_repo = gh.repository("DragonOS-Community/DragonOS").await?;
+        let prs = retrieve_pull_requests(&dragonos_repo, &gh).await?;
 
         // delete all PR assignments before populating
         init_table(&db).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ async fn run_server(addr: SocketAddr) -> anyhow::Result<()> {
         .expect("Failed to build octograb.");
     let ctx = Arc::new(Context {
         username: std::env::var("TRIAGEBOT_USERNAME").or_else(|err| match err {
-            std::env::VarError::NotPresent => Ok("rustbot".to_owned()),
+            std::env::VarError::NotPresent => Ok("dragonosbot".to_owned()),
             err => Err(err),
         })?,
         db: pool,


### PR DESCRIPTION
## **Type**
Bug fix, Enhancement


___

## **Description**
This PR updates the bot's name and GitHub organization from "rust-lang" to "Dragon


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Update bot GitHub login</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

github-graphql/src/lib.rs
- Changed the bot's GitHub login from "rust-lang" to <br>  "DragonOS-Community".
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-ff2c3ff9f14eaa007af80162889c12384e217e6264ca13b0a0fd46cf25701fb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>command.rs</strong><dd><code>Update bot name in test input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser/src/command.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the test <br>  input.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-1eb763ec24cd0509bade43f86001d94744947818b6ea7596c4e003c858327395">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Update bot name in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the <br>  configuration labels.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>github.rs</strong><dd><code>Update bot GitHub organization in API calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/github.rs
- Updated the bot's GitHub organization name from "rust-lang" to <br>  "DragonOS-Community" in the GitHub API calls.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-ef5fd0828e2727ce9e100f72dc4f18f0f126e393d35108269a9bea5e8a104d5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>assign.rs</strong><dd><code>Update bot name in assignment handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/assign.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the <br>  assignment handlers.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-986c56635b36aad01d962591764a42e846b7ce5f662200381f10799e6d8747f3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docs_update.rs</strong><dd><code>Update bot name in documentation update job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/docs_update.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the <br>  documentation update job.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-a32abbce644c127d2faa94119e293fdd85524bed5facc81b7988d43d1d69a2ac">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>major_change.rs</strong><dd><code>Update bot name in major change handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/major_change.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the major <br>  change handling comments.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-a618edcce47f7e4d85a69cf2457881623519c5b9f83be1b023ca09eb7f98bcbe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>milestone_prs.rs</strong><dd><code>Update bot GitHub organization in milestone PR handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/milestone_prs.rs
- Updated the bot's GitHub organization name from "rust-lang" to <br>  "DragonOS-Community" in the milestone PR handling logic.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-4bcd39146a8828d482ffaa91c48dbaaaa0f3098cd02e115483f6b537b263371d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>note.rs</strong><dd><code>Update bot name in note handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/note.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the note <br>  handling comments.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-b93b9a99f3168886f75e966da57a97b1de19d1d6a5c28a0514235d52732294a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pull_requests_assignment_update.rs</strong><dd><code>Update bot GitHub organization in pull request assignment update</code>&nbsp; </dd></summary>
<hr>

src/handlers/pull_requests_assignment_update.rs
- Updated the bot's GitHub organization name from "rust-lang" to <br>  "DragonOS-Community" in the pull request assignment update logic.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-8ed95c398fa9e1bf1a804605cd7caf19e34d2af24c33019d99e43a661ff30c4a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Update bot name in main application logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.rs
- Updated the bot's name from "rustbot" to "dragonosbot" in the main <br>  application logic.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update bot name in repository URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml
- Updated the bot's name from "rustbot" to "dragonosbot" in the <br>  repository URL.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update bot name in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
- Updated the bot's name from "rust-lang" to "DragonOS-Community" in the <br>  README.
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
