### PR TITLE
disable merge commit checking

### DIFF
--- a/src/handlers/no_merges.rs
+++ b/src/handlers/no_merges.rs
@@ -11,7 +11,6 @@ use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fmt::Write;
-use tracing as log;
 
 const NO_MERGES_KEY: &str = "no_merges";
 
@@ -30,7 +29,7 @@ struct NoMergesState {
 }
 
 pub(super) async fn parse_input(
-    ctx: &Context,
+    _ctx: &Context,
     event: &IssuesEvent,
     config: Option<&NoMergesConfig>,
 ) -> Result<Option<NoMergesInput>, String> {
@@ -42,7 +41,7 @@ pub(super) async fn parse_input(
     }
 
     // Require a `[no_merges]` configuration block to enable no-merges notifications.
-    let Some(config) = config else {
+    let Some(_config) = config else {
         return Ok(None);
     };
 
@@ -51,33 +50,37 @@ pub(super) async fn parse_input(
         return Ok(None);
     }
 
+    return Ok(None);
+    // DragonOS社区目前允许merge commit, 所以这里不需要检查
+
+
     // Don't trigger if the PR has any of the excluded title segments.
-    if config
-        .exclude_titles
-        .iter()
-        .any(|s| event.issue.title.contains(s))
-    {
-        return Ok(None);
-    }
+    // if config
+    //     .exclude_titles
+    //     .iter()
+    //     .any(|s| event.issue.title.contains(s))
+    // {
+    //     return Ok(None);
+    // }
 
-    let mut merge_commits = HashSet::new();
-    let commits = event
-        .issue
-        .commits(&ctx.github)
-        .await
-        .map_err(|e| {
-            log::error!("failed to fetch commits: {:?}", e);
-        })
-        .unwrap_or_default();
-    for commit in commits {
-        if commit.parents.len() > 1 {
-            merge_commits.insert(commit.sha.clone());
-        }
-    }
+    // let mut merge_commits = HashSet::new();
+    // let commits = event
+    //     .issue
+    //     .commits(&ctx.github)
+    //     .await
+    //     .map_err(|e| {
+    //         log::error!("failed to fetch commits: {:?}", e);
+    //     })
+    //     .unwrap_or_default();
+    // for commit in commits {
+    //     if commit.parents.len() > 1 {
+    //         merge_commits.insert(commit.sha.clone());
+    //     }
+    // }
 
-    // Run the handler even if we have no merge commits,
-    // so we can take an action if some were removed.
-    Ok(Some(NoMergesInput { merge_commits }))
+    // // Run the handler even if we have no merge commits,
+    // // so we can take an action if some were removed.
+    // Ok(Some(NoMergesInput { merge_commits }))
 }
 
 const DEFAULT_MESSAGE: &str = "


### PR DESCRIPTION
## **Type**
Bug fix, Other


___

## **Description**
此拉取请求移除了对合并提交检查的代码，以符合DragonOS社区的当前政策。同时，对一些代码行进行了注释，以提供未来的参考。


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>no_merges.rs</strong><dd><code>移除合并提交检查</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/no_merges.rs
[{'-8,13 +8,12': '移除了对合并提交检查的代码'}, {'-27,13 +26,13': '移除了对合并提交的处理的代码'}, {'-39,13 +38,13': '移除了对合并提交检查的代码'}, {'-48,39 +47,43': '移除了对合并提交检查的代码，并添加了一些注释说明'}]
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/10/files#diff-8c339e442d8cbbadd32bc50454fb0bccb1e9952c9def237a3f85aabe1251d603">+31/-28</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
