### PR TITLE
修复“等待审查”和“等待修改”的label判断问题

### DIFF
--- a/github-graphql/src/lib.rs
+++ b/github-graphql/src/lib.rs
@@ -36,7 +36,7 @@ pub mod queries {
             states: "OPEN",
             first: 100,
             after: $after,
-            labels: ["S-waiting-on-review"],
+            labels: ["S-等待审查"],
             orderBy: {direction: "ASC", field: "UPDATED_AT"}
         )]
         pub pull_requests: PullRequestConnection,

--- a/src/handlers/assign.rs
+++ b/src/handlers/assign.rs
@@ -39,13 +39,13 @@ mod tests {
 }
 
 const NEW_USER_WELCOME_MESSAGE: &str = "Thanks for the pull request, and welcome! \
-The Rust team is excited to review your changes, and you should hear from {who} \
+The DragonOS Community is excited to review your changes, and you should hear from {who} \
 some time within the next two weeks.";
 
 const CONTRIBUTION_MESSAGE: &str = "Please see [the contribution \
 instructions]({contributing_url}) for more information. Namely, in order to ensure the \
 minimum review times lag, PR authors and assigned reviewers should ensure that the review \
-label (`S-waiting-on-review` and `S-waiting-on-author`) stays updated, invoking these commands \
+label (`S-等待审查` and `S-等待作者修改`) stays updated, invoking these commands \
 when appropriate:
 
 - `@{bot} author`: the review is finished, PR author should check the comments and take action accordingly

--- a/src/handlers/shortcut.rs
+++ b/src/handlers/shortcut.rs
@@ -26,8 +26,8 @@ pub(super) async fn handle_command(
     }
 
     let issue_labels = issue.labels();
-    let waiting_on_review = "S-waiting-on-review";
-    let waiting_on_author = "S-waiting-on-author";
+    let waiting_on_review = "S-等待审查";
+    let waiting_on_author = "S-等待作者修改";
     let blocked = "S-blocked";
     let status_labels = [waiting_on_review, waiting_on_author, blocked];
 

--- a/src/triage.rs
+++ b/src/triage.rs
@@ -78,8 +78,8 @@ pub async fn pulls(
                 .collect::<Vec<_>>()
                 .join(", ")
         });
-        let wait_for_author = labels.contains("S-waiting-on-author");
-        let wait_for_review = labels.contains("S-waiting-on-review");
+        let wait_for_author = labels.contains("S-等待作者修改");
+        let wait_for_review = labels.contains("S-等待审查");
         let html_url = base_pull.html_url.unwrap();
         let number = base_pull.number;
         let title = base_pull.title.unwrap();

--- a/templates/prioritization_agenda.tt
+++ b/templates/prioritization_agenda.tt
@@ -132,7 +132,7 @@ don't know
 
 (TIP) Curate this list before the meeting
 
-[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-waiting-on-review+draft%3Afalse+label%3AT-compiler)
+[T-compiler](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-asc+label%3AS-等待审查+draft%3Afalse+label%3AT-compiler)
 {{-issues::render(issues=top_unreviewed_prs, with_age=true, empty="No unreviewed PRs on `T-compiler` this time.")}}
 
 ## Next week's WG checkins


### PR DESCRIPTION
## **Type**
Bug fix, Documentation


___

## **Description**
此拉取请求主要修复了几个与标签判断相关的问题，并更新了相关文档。具体更改包括： 1. 修复了“等待审查”和“等待修改”的label判断问题。 2. 更新了新用户欢迎消息和贡献指南。 3. 修复了快捷命令错误消息和标签名称。 4. 修复了拉取请求标签判断问题。 5. 更新了优先级议程中的审查链接。


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>修复“等待审查”和“等待修改”的label判断问题</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

github-graphql/src/lib.rs
['Fixes the label judgment for "等待审查" and "等待修改"']
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/11/files#diff-ff2c3ff9f14eaa007af80162889c12384e217e6264ca13b0a0fd46cf25701fb1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>shortcut.rs</strong><dd><code>修复快捷命令错误消息和标签名称</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/shortcut.rs
['Updates the error message for incorrect command usage', 'Corrects the label names for "等待审查" and "等待作者修改"']
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/11/files#diff-b963a8e4a7e496b4d7e23a207e96dd15073c6cb6427c731de2bd6ee8a242eedd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>triage.rs</strong><dd><code>修复拉取请求标签判断问题</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/triage.rs
['Corrects the label names for "等待审查" and "等待作者修改"']
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/11/files#diff-776667fa275ae2dd70136366ce1f8428187257bcf1669cbe0c1eaa3f62758749">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assign.rs</strong><dd><code>更新新用户欢迎消息和贡献指南</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/handlers/assign.rs
['Updates the welcome message for new users', 'Changes the contribution message to include the correct label names']
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/11/files#diff-986c56635b36aad01d962591764a42e846b7ce5f662200381f10799e6d8747f3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>prioritization_agenda.tt</strong><dd><code>更新优先级议程中的审查链接</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/prioritization_agenda.tt
['Updates the link to the "等待审查" labeled PRs']
    </details>
  </td>
  <td><a href="https://github.com/DragonOS-Community/triagebot/pull/11/files#diff-45aaa066f84a95b64c007930cb7a9cf7f0c249f1cf22c3d300a9ccfcbf08bf4b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
